### PR TITLE
Fix rename issue

### DIFF
--- a/slp_rename.js
+++ b/slp_rename.js
@@ -132,6 +132,8 @@ for (const dir of directories) {
               console.log(`Renamed: ${filePath} -> ${newPath}`);
             }
           });
+        } else {
+          console.log(`${filePath} -> ${newPath}`);
         }
       }
     })

--- a/slp_rename.js
+++ b/slp_rename.js
@@ -27,7 +27,7 @@ function playerName(player, metadata) {
   }
 
   if (playerIds.length > 0) {
-    return `${character} (${playerIds.join('/')})`;
+    return `${character} (${playerIds.join(',')})`;
   } else {
     return character;
   }
@@ -124,12 +124,12 @@ for (const dir of directories) {
         }
 
         const newPath = path.join(dir, newName);
-        console.log(`${filePath} -> ${newPath}`);
-
         if (!argv.n) {
           fs.rename(filePath, newPath, err => {
             if (err) {
               console.log(`Error renaming ${filePath}: ${err}`);
+            } else {
+              console.log(`Renamed: ${filePath} -> ${newPath}`);
             }
           });
         }


### PR DESCRIPTION
Closes #6.

Issue was that `/` is not usable for file names. Multiple ids are now joined with `,`s.

Also moved the renamed log inside of the `.rename` callback.