### PR TITLE
Use metadata to construct date prefix

### DIFF
--- a/slp_rename.js
+++ b/slp_rename.js
@@ -72,8 +72,15 @@ function prettyPrintSingles(settings, metadata) {
 function parsedFilename(settings, metadata, file) {
   const dateRegex = file.match('_([^\.]+)');
 
+  let datePrefix = null;
   if (!dateRegex) {
-    return null;
+    if (!metadata) {
+      return null;
+    }
+    let dateStr = metadata.startAt.split('-').join('').split(':').join('');
+    datePrefix = dateStr.substring(0, dateStr.length - 1);
+  } else {
+    datePrefix = dateRegex[1];
   }
 
   let pretty = null;
@@ -87,7 +94,7 @@ function parsedFilename(settings, metadata, file) {
     return null;
   }
 
-  return `${dateRegex[1]} - ${pretty}.slp`
+  return `${datePrefix} - ${pretty}.slp`
 }
 
 const directories = argv._;
@@ -129,11 +136,11 @@ for (const dir of directories) {
             if (err) {
               console.log(`Error renaming ${filePath}: ${err}`);
             } else {
-              console.log(`Renamed: ${filePath} -> ${newPath}`);
+              console.log(`Renamed: ${file} -> ${newName}`);
             }
           });
         } else {
-          console.log(`${filePath} -> ${newPath}`);
+          console.log(`${file} -> ${newName}`);
         }
       }
     })

--- a/slp_rename.js
+++ b/slp_rename.js
@@ -77,7 +77,7 @@ function parsedFilename(settings, metadata, file) {
     if (!metadata) {
       return null;
     }
-    let dateStr = metadata.startAt.split('-').join('').split(':').join('');
+    const dateStr = metadata.startAt.replace(/[-:]/g, '');
     datePrefix = dateStr.substring(0, dateStr.length - 1);
   } else {
     datePrefix = dateRegex[1];


### PR DESCRIPTION
Closes #8.

- uses `.slp` `metadata` to construct date prefixes when the regex fails (i.e., when a file is named something other than `Game_<DATE>.slp` or has already been renamed)
- Shortens the log for renames (i.e., removes the path and only shows the file names); see below

Only caveat here is that it seems the `metadata` date is (my guess) in UTC, while the original file name (i.e., the one capture by the regex) is in local time. The following log shows the difference in time.

```
2020-06-16T23:03:42Z
20200616T190342 - Fox (FoxInTheB0XX) vs Luigi (White,Ugly) - Yoshi's Story.slp -> 20200616T230342 - Fox (FoxInTheB0XX) vs Luigi (White,Ugly) - Yoshi's Story.slp
```

Lmk if this is a problem.